### PR TITLE
Chore: automatic releasing

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,15 +1,16 @@
 name: Publish to Pypi
 on:
   push:
-    branches:
-      - 'master'
+    tags:
+      - '*'
 
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - name: Checkout
+      uses: actions/checkout@master
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
@@ -20,6 +21,12 @@ jobs:
         pip install
         build
         --user
+    - name: Extract tag name
+      id: tag
+      run: echo ::set-output name=TAG_NAME::$(echo $GITHUB_REF | cut -d / -f 3)
+    - name: Update version in setup.py
+      run: >-
+        sed -i "s/{{VERSION_PLACEHOLDER}}/${{ steps.tag.outputs.TAG_NAME }}/g" setup.py
     - name: Build a binary wheel and a source tarball
       run: >-
         python -m
@@ -27,14 +34,12 @@ jobs:
         --sdist
         --wheel
         --outdir dist/
-        .
     - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -244,19 +244,18 @@ When incrementing the MINOR version, reset the PATCH version to 0.
 
 When a version is released, a tag should be created in the format `vMAJOR.MINOR.PATCH`.
 
-Follow the steps below to create a new release:
-1. Update `package.json` with the new version number.
-2. Add the tag to the current branch like this:
+A new version is not automatically released upon merging into master. Follow the steps below to create a new release:
+
+1. Add the tag to the current branch like this:
 
 ```
 git tag -a v1.0.0 -m "Release version 1.0.0"
 ```
-3. Push the tag to the remote repository:
+2. Push the tag to the remote repository:
 
 ```
 git push origin --tags
 ```
-4. Create a new pull request with the new version number and merge it to the `master` branch.
 
 ### <a name="contributors">:pencil: Contributors</a>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "osmanager",
-  "version": "1.0.2",
   "description": "OpenSearch manager repository.",
   "author": "STRV DS Department <datascience.dept@strv.com>",
   "email": "datascience.dept@strv.com",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ package_info = json.loads(package_info)
 
 setup(
     name=package_info["name"],
-    version=package_info["version"],
+    version="{{VERSION_PLACEHOLDER}}",
     author=package_info["author"],
     author_email=package_info["email"],
     url=package_info["url"],


### PR DESCRIPTION
## :memo: Changelog

- [x] extract the tag from github afer pushing the tag and insert it into setup.py
- [x] make releasing independent of merging into master, but dependent on pushing a new tag
- [x] remove version number from package.json 

## :link: Links

  - [JIRA issue](https://github.com/strvcom/osman/issues/69)

## :white_check_mark: Checklist

- [x] Lint and tests pass locally with my changes
- [x] I've added necessary documentation
